### PR TITLE
TASK: Require  jobqueue-common 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "ext-redis": "*",
-        "flowpack/jobqueue-common": "^1.0"
+        "flowpack/jobqueue-common": "^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This changes the dependency on jobqueue-common from 1.0 to 2.0, since that is
the version matching Flow 4.x.